### PR TITLE
Add Text Component

### DIFF
--- a/src/components/elements/Text.tsx
+++ b/src/components/elements/Text.tsx
@@ -1,0 +1,25 @@
+import { createElement, type PropsWithChildren } from "react"
+import type { HTMLTextType } from '../../../types'
+
+
+interface TextProps extends PropsWithChildren {
+    variant?: HTMLTextType;
+    level?: HTMLTextType;
+}
+
+
+const variantMap: Record<HTMLTextType, string> = {
+    h1: 'text-6xl font-semibold',
+    h2: 'text-5xl font-semibold',
+    h3: 'text-4xl font-medium',
+    h4: 'text-2xl font-extralight uppercase',
+    h5: 'text-1xl font-semibold',
+    h6: 'text:base font-bold',
+    p: 'text-sm',
+}
+
+export const Text = (props: TextProps) => {
+    const { children, level = 'p', variant = 'p' } = props;
+
+    return createElement(level, { className: variantMap[variant] }, children)
+}

--- a/src/components/elements/index.ts
+++ b/src/components/elements/index.ts
@@ -1,0 +1,1 @@
+export * from './Text';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
-export * from './TextInput'
+export * from './TextInput';
+export * from './elements'

--- a/src/stories/Text.stories.ts
+++ b/src/stories/Text.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Text, } from '../components';
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+    title: 'Elements/Text',
+    component: Text,
+    // parameters: {
+    //   // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    //   layout: 'centered',
+    // },
+    // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+    tags: ['autodocs'],
+    // More on argTypes: https://storybook.js.org/docs/api/argtypes
+    // argTypes: {
+    //   variant: { control: 'text' },
+    // },
+    // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+    // args: { variant: 'string' },
+} satisfies Meta<typeof Text>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Paragraph: Story = {
+    args: {
+        children: 'Heyyyyy',
+        level: 'h1',
+        variant: 'h1'
+    },
+};

--- a/types/htmlTypes.ts
+++ b/types/htmlTypes.ts
@@ -1,0 +1,1 @@
+export type HTMLTextType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,1 @@
+export * from './htmlTypes'


### PR DESCRIPTION
# Handle Text
<!-- Problem Statement or brief description of overall changes -->

Added ability for library to generate text fields, and styles by prop input and children. Kind of the `<Typography />` component from MUI but implementing my style guide.

## Changes Made
<!-- Bullet point list of changes introduced by this PR -->

Above changes and
* added a type for the `variant` and `level` props to use
* added a few more `index.ts` files for exports

## Testing Information
<!-- Checklist of testable things from this PR -->

- [ ] styles for `variant` are applied
- [ ] correct tag from `level` is used
- [ ] above two conditions are not mutually exclusive

## Visuals
<!-- Visual changes from this PR -->

https://github.com/user-attachments/assets/d5e375f4-76f2-429b-9e81-899f7c78d7a7

## Notes
<!-- Anything else? -->

Styles will need a bit more refining when the style guide is finished, but this is a good enough start to work with.